### PR TITLE
Adding ct-calculations build top ci-open

### DIFF
--- a/jobs/cato.groovy
+++ b/jobs/cato.groovy
@@ -8,3 +8,6 @@ new SbtLibraryJobBuilder('play-events').
 
 new SbtLibraryJobBuilder('attachments-client', JDK7).
         build(this as DslFactory)
+
+new SbtLibraryJobBuilder('ct-calculations', JDK7).
+        build(this as DslFactory)


### PR DESCRIPTION
Note please that using JDK 7 is deliberate. We cannot move this library to JDK 8 until our services have upgraded. 