### PR TITLE
AOSS-1293: Replace agent-self-assessment with agent-access-control

### DIFF
--- a/jobs/ci_open_jenkins/build/agents.groovy
+++ b/jobs/ci_open_jenkins/build/agents.groovy
@@ -1,8 +1,6 @@
 package ci_open_jenkins.build
 
 import javaposse.jobdsl.dsl.DslFactory
-import uk.gov.hmrc.jenkinsjobs.domain.builder.SbtLibraryJobBuilder
 import uk.gov.hmrc.jenkinsjobs.domain.builder.SbtMicroserviceJobBuilder
 
-new SbtMicroserviceJobBuilder('agent-self-assessment').build(this as DslFactory)
-
+new SbtMicroserviceJobBuilder('agent-access-control').build(this as DslFactory)


### PR DESCRIPTION
We've decided to start off with one micro-service for all the tax regimes instead of a micro-service per tax regime.