### PR TITLE
Scoverage 1.3.4+ fix

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/SbtMicroserviceJobBuilder.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/SbtMicroserviceJobBuilder.groovy
@@ -50,6 +50,7 @@ final class SbtMicroserviceJobBuilder implements Builder<Job> {
     SbtMicroserviceJobBuilder withSCoverage() {
         beforeTest += "coverage"
         afterTest += "coverageOff"
+        afterTest += "coverageReport"
         jobBuilder = jobBuilder.withConfigures(sCoverageReportsPublisher())
         this
     }

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/SbtMicroserviceJobBuilderSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/SbtMicroserviceJobBuilderSpec.groovy
@@ -71,7 +71,7 @@ class SbtMicroserviceJobBuilderSpec extends Specification {
 
         then:
         with(job.node) {
-            builders.'hudson.tasks.Shell'.command.text().contains('sbt $SBT_OPTS clean validate coverage test coverageOff dist-tgz publishSigned')
+            builders.'hudson.tasks.Shell'.command.text().contains('sbt $SBT_OPTS clean validate coverage test coverageOff coverageReport dist-tgz publishSigned')
             publishers.'org.jenkinsci.plugins.scoverage.ScoveragePublisher'.reportDir.text() == "target/scala-2.11/scoverage-report"
             publishers.'org.jenkinsci.plugins.scoverage.ScoveragePublisher'.reportFile.text() == "scoverage.xml"
         }
@@ -100,7 +100,7 @@ class SbtMicroserviceJobBuilderSpec extends Specification {
 
         then:
         with(job.node) {
-            builders.'hudson.tasks.Shell'.command.text().contains('sbt $SBT_OPTS clean validate scalastyle coverage test coverageOff dist-tgz publishSigned')
+            builders.'hudson.tasks.Shell'.command.text().contains('sbt $SBT_OPTS clean validate scalastyle coverage test coverageOff coverageReport dist-tgz publishSigned')
             publishers.'org.jenkinsci.plugins.scoverage.ScoveragePublisher'.reportDir.text() == "target/scala-2.11/scoverage-report"
             publishers.'org.jenkinsci.plugins.scoverage.ScoveragePublisher'.reportFile.text() == "scoverage.xml"
             publishers.'hudson.plugins.checkstyle.CheckStylePublisher'.pluginName.text() == "[CHECKSTYLE]"


### PR DESCRIPTION
scoverage plugin > 1.3.4 don't implicitly generate the scoverage-report folder any more during testing. This is delegated to the coverageReport task. This task exists in earlier versions of the plugin and is the intended way to generate reports (it appears this was an unintended side-effect at the end of each test phase that has now been removed). Adding an explicit coverageReport to the jobs post coverageOff ensures the generation of the reports folder for all versions of the plugin.