### PR TITLE
Extend the build timeouts for CSR projects with integration tests

### DIFF
--- a/jobs/ci_open_jenkins/build/csr.groovy
+++ b/jobs/ci_open_jenkins/build/csr.groovy
@@ -7,6 +7,7 @@ import uk.gov.hmrc.jenkinsjobs.domain.builder.SbtMicroserviceJobBuilder
 
 
 new SbtMicroserviceJobBuilder('fset-faststream').
+    withExtendedTimeout().
     build(this as DslFactory)
     
 new SbtFrontendJobBuilder('fset-faststream-frontend').
@@ -14,6 +15,7 @@ new SbtFrontendJobBuilder('fset-faststream-frontend').
 
 
 new SbtMicroserviceJobBuilder('fset-fasttrack').
+    withExtendedTimeout().
     build(this as DslFactory)
 
 new SbtFrontendJobBuilder('fset-fasttrack-frontend').


### PR DESCRIPTION
The ci build node is considerably slower that other environments, so extend the timeouts for the builds until more resources are added, or the tests are optimised further.