### PR TITLE
Make use of new timeout parameters in Releaser 0.14

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/step/Steps.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/step/Steps.groovy
@@ -36,7 +36,7 @@ class Steps {
                   |  mkdir -p ~/.m2/repository/uk/gov/hmrc/releaser_2.11/\$RELEASER_VERSION
                   |  curl -L -k -o ~/.m2/repository/uk/gov/hmrc/releaser_2.11/\$RELEASER_VERSION/releaser_2.11-\$RELEASER_VERSION-assembly.jar https://dl.bintray.com/hmrc/releases/uk/gov/hmrc/releaser_2.11/\$RELEASER_VERSION/releaser_2.11-\$RELEASER_VERSION-assembly.jar
                   |fi
-                  |java \$JAVA_PROXY_OPTS -jar ~/.m2/repository/uk/gov/hmrc/releaser_2.11/\$RELEASER_VERSION/releaser_2.11-\$RELEASER_VERSION-assembly.jar \$ARTEFACT_NAME \$RELEASE_CANDIDATE_VERSION \$RELEASE_TYPE
+                  |java \$JAVA_PROXY_OPTS -Dwsclient.timeout.connection=300 -Dwsclient.timeout.idle=300 -Dwsclient.timeout.request=300 -jar ~/.m2/repository/uk/gov/hmrc/releaser_2.11/\$RELEASER_VERSION/releaser_2.11-\$RELEASER_VERSION-assembly.jar \$ARTEFACT_NAME \$RELEASE_CANDIDATE_VERSION \$RELEASE_TYPE
                   """.stripMargin())
     }
 


### PR DESCRIPTION
@ashusingh Thanks for merging the new version of releaser, perhaps you're best placed to review this one adding the timeout arguments in to the jenkins job?

If you were looking at the job in ci-open you'd see the parameters are already there, i've added them manually for the moment