### PR TITLE
Revert "Removed withoutJUnitReports from logback-json-logger"

### DIFF
--- a/jobs/ci_open_jenkins/build/bta.groovy
+++ b/jobs/ci_open_jenkins/build/bta.groovy
@@ -28,6 +28,7 @@ new SbtLibraryJobBuilder('play-url-binders').
         build(this as DslFactory)
 
 new SbtLibraryJobBuilder('logback-json-logger').
+        withoutJUnitReports().
         build(this as DslFactory)
 
 new BuildMonitorViewBuilder('BTA-OPEN-DEV-MONITOR')


### PR DESCRIPTION
This reverts commit 18fe6e75b1cffcd5d5fe32cf4363db7df63a3ddb.
The job fails because no tests reports are produced