### PR TITLE
PLATOPS-1254: REMOVE mongo-tls-progress-frontend to platops open builds

### DIFF
--- a/jobs/ci_open_jenkins/build/platops.groovy
+++ b/jobs/ci_open_jenkins/build/platops.groovy
@@ -192,9 +192,6 @@ new SbtMicroserviceJobBuilder('service-dependencies').withTests("test")
 new SbtMicroserviceJobBuilder('library-upgrade-progress-frontend').withTests("test")
         .build(this as DslFactory)
 
-new SbtMicroserviceJobBuilder('mongo-tls-progress-frontend').withTests("test")
-        .build(this as DslFactory)
-
 new SbtLibraryJobBuilder('github-client').build(this as DslFactory)
 
 new SbtLibraryJobBuilder('git-client').build(this as DslFactory)


### PR DESCRIPTION
After discussion with Pete Smith about the sensitivity of the
proposed service.

This reverts commit 6232af9e029c5c7a44d4af7ae4561c9b8a4b9751.