### PR TITLE
Revert "PLATY-472 Created configuration for upscan-notify utility ser…

### DIFF
--- a/jobs/ci_open_jenkins/build/platform-services.groovy
+++ b/jobs/ci_open_jenkins/build/platform-services.groovy
@@ -21,10 +21,5 @@ new SbtMicroserviceJobBuilder('upscan-notify').
         withScalaStyle().
         build(this as DslFactory)
 
-new SbtMicroserviceJobBuilder('upscan-listener').
-        withSCoverage().
-        withScalaStyle().
-        build(this as DslFactory)
-
 new BuildMonitorViewBuilder('PLATSERVICES-MONITOR')
         .withJobs('contact-admin', 'upscan-initiate', 'upscan-notify').build(this)


### PR DESCRIPTION
…vice"

The service is private, so it shouldn't be built using ci-open jenkins

This reverts commit b5a4adff62d872882ad9c3819c2da2a47ac5332d.