### PR TITLE
PBD-121 NPM will now pull dependencies from the public registry, but publish to Bintray

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilder.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilder.groovy
@@ -6,8 +6,9 @@ import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.Builder
 import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.JobBuilder
 
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.AbsoluteTimeoutWrapper.timeoutWrapper
-import static uk.gov.hmrc.jenkinsjobs.domain.builder.JobBuilders.jobBuilder
-import static uk.gov.hmrc.jenkinsjobs.domain.publisher.Publishers.*
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.SecretTextCredentialsWrapper.secretTextCredentials
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.model.SecretText.secretText
+import static uk.gov.hmrc.jenkinsjobs.domain.publisher.Publishers.defaultBuildDescriptionPublisher
 import static uk.gov.hmrc.jenkinsjobs.domain.step.Steps.npmRelease
 
 final class NpmLibraryJobBuilder implements Builder<Job> {

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilder.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilder.groovy
@@ -28,7 +28,12 @@ final class NpmLibraryJobBuilder implements Builder<Job> {
 
     Job build(DslFactory dslFactory) {
         jobBuilder.withSteps(npmRelease(nodeVersion)).
-                withWrappers(timeoutWrapper(this.timeout)).
+                withWrappers(
+                        timeoutWrapper(this.timeout),
+                        secretTextCredentials(
+                                secretText('BINTRAY_CREDENTIALS', 'npm-hmrc-bintray-creds')
+                        )
+                ).
                 build(dslFactory)
     }
 

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/step/Steps.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/step/Steps.groovy
@@ -60,9 +60,9 @@ class Steps {
                   |  npm pack \$version
                   |done
                   |
-                  |cat >$WORKSPACE/.npmrc <<EOL
+                  |cat >\${WORKSPACE}/.npmrc <<EOL
                   |registry=https://api.bintray.com/npm/hmrc/npm-release-candidates
-                  |_auth=$BINTRAY_CREDENTIALS
+                  |_auth=\${BINTRAY_CREDENTIALS}
                   |email=hmrc-build-and-deploy@digital.hmrc.gov.uk
                   |always-auth=true
                   |EOL

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/step/Steps.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/step/Steps.groovy
@@ -56,12 +56,19 @@ class Steps {
                   |
                   |mkdir dist && cd dist
                   |
-                  |for version in \$(find ../assets/public/* -type d -d 0); do
+                  |for version in \$(find ../assets/public/* -maxdepth 0 -type d); do
                   |  npm pack \$version
                   |done
                   |
+                  |cat >$WORKSPACE/.npmrc <<EOL
+                  |registry=https://api.bintray.com/npm/hmrc/npm-release-candidates
+                  |_auth=$BINTRAY_CREDENTIALS
+                  |email=hmrc-build-and-deploy@digital.hmrc.gov.uk
+                  |always-auth=true
+                  |EOL
+                  |
                   |for releaseCandidate in \$(find *.tgz); do
-                  |  npm publish \$releaseCandidate --registry https://api.bintray.com/npm/hmrc/npm-release-candidates
+                  |  npm publish \$releaseCandidate
                   |done
                   """.stripMargin())
     }


### PR DESCRIPTION
This has been approved by @rpowis. This is currently for release-candidates only. The current theory is that we'll split the publish stuff into a separate build step when we get to playing the ticket about publishing releases to the public registry.