### PR TITLE
Extend assets-frontend timeout to 30 mins

### DIFF
--- a/jobs/ci_open_jenkins/build/sdt.groovy
+++ b/jobs/ci_open_jenkins/build/sdt.groovy
@@ -8,6 +8,7 @@ import uk.gov.hmrc.jenkinsjobs.domain.builder.SbtFrontendJobBuilder
 import uk.gov.hmrc.jenkinsjobs.domain.builder.NpmLibraryJobBuilder
 
 new NpmLibraryJobBuilder('assets-frontend')
+        .withExtendedTimeout()
         .build(this as DslFactory)
 
 new NpmLibraryJobBuilder('node-git-versioning')

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilder.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilder.groovy
@@ -45,4 +45,9 @@ final class NpmLibraryJobBuilder implements Builder<Job> {
         this.nodeVersion = version
         this
     }
+
+    NpmLibraryJobBuilder withExtendedTimeout() {
+        this.timeout = 30
+        this
+    }
 }

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilderSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobs/domain/builder/NpmLibraryJobBuilderSpec.groovy
@@ -50,4 +50,17 @@ class NpmLibraryJobBuilderSpec extends Specification {
                                                                     |nvm use ${nodeVersion}""".stripMargin())
         }
     }
+
+    void 'test extended build timeout'() {
+        given:
+        NpmLibraryJobBuilder jobBuilder = new NpmLibraryJobBuilder('test-job')
+
+        when:
+        Job job = jobBuilder.withExtendedTimeout().build(jobParent())
+
+        then:
+        with(job.node) {
+            buildWrappers.'hudson.plugins.build__timeout.BuildTimeoutWrapper'.strategy.timeoutMinutes.text() == '30'
+        }
+    }
 }


### PR DESCRIPTION
assets-frontend is hitting the default 15mins timeout so it was pushing to nexus (for service-manager to download from) but failing to deploy to S3 (for production frontends to use). 

This fixes that by allowing the timeout to be extended as per other jobs.