### PR TITLE
DDCNOS-861: Removing tax-summaries repos

### DIFF
--- a/jobs/ci_open_jenkins/build/ddcn-live-service.groovy
+++ b/jobs/ci_open_jenkins/build/ddcn-live-service.groovy
@@ -141,22 +141,6 @@ new SbtFrontendJobBuilder('off-payroll-frontend').
         withTests("test").
         build(this as DslFactory)
 
-
-new SbtFrontendJobBuilder('tax-summaries-frontend').
-        withScalaStyle().
-        withSCoverage().
-        build(this as DslFactory)
-
-new SbtMicroserviceJobBuilder('tax-summaries').
-        withScalaStyle().
-        withSCoverage().
-        build(this as DslFactory)
-
-new SbtMicroserviceJobBuilder('tax-summaries-agent').
-        withScalaStyle().
-        withSCoverage().
-        build(this as DslFactory)
-
 new SbtFrontendJobBuilder('pdf-generator-frontend').
         withTests("test").
         withLogRotator(7, 1000).


### PR DESCRIPTION
Removing tax-summaries, tax-summaries-agent and tax-summaries-frontend and moving to new deployment process