### PR TITLE
Removing `http-verbs-play-25` `http-verbs-play-26` as these libraries…

### DIFF
--- a/jobs/ci_open_jenkins/build/platops.groovy
+++ b/jobs/ci_open_jenkins/build/platops.groovy
@@ -92,7 +92,3 @@ new SbtMicroserviceJobBuilder('sample-reactivemongo').withTests("test")
         .build(this as DslFactory)
 
 new SbtLibraryJobBuilder('init-prototype').build(this as DslFactory)
-
-new SbtLibraryJobBuilder('http-verbs-play-25').build(this as DslFactory)
-
-new SbtLibraryJobBuilder('http-verbs-play-26').build(this as DslFactory)

--- a/jobs/ci_open_jenkins/build/txm.groovy
+++ b/jobs/ci_open_jenkins/build/txm.groovy
@@ -3,9 +3,6 @@ package ci_open_jenkins.build
 import javaposse.jobdsl.dsl.DslFactory
 import uk.gov.hmrc.jenkinsjobs.domain.builder.SbtLibraryJobBuilder
 
-new SbtLibraryJobBuilder('http-verbs').
-        build(this as DslFactory)
-
 new SbtLibraryJobBuilder('auditing').
         build(this as DslFactory)
 


### PR DESCRIPTION
… are deprecated.

Removing `http-verbs` from txm.groovy. This library has been already migrated.