### PR TITLE
Migrating mongo-caching to new build.

### DIFF
--- a/jobs/ci_open_jenkins/build/auth.groovy
+++ b/jobs/ci_open_jenkins/build/auth.groovy
@@ -28,9 +28,6 @@ new SbtLibraryJobBuilder('play-json-logger').
 new SbtLibraryJobBuilder('Play-Reactivemongo').
         build(this as DslFactory)
 
-new SbtLibraryJobBuilder('mongo-caching').
-        build(this as DslFactory)
-
 new SbtLibraryJobBuilder('play-breadcrumb').
         build(this as DslFactory)
 


### PR DESCRIPTION
Mongo-caching is owned by platops.