### PR TITLE
ET-Fix-Scoverage-build-issue-for-sbt.2.12

### DIFF
--- a/jobs/ci_open_jenkins/build/ssttp.groovy
+++ b/jobs/ci_open_jenkins/build/ssttp.groovy
@@ -12,7 +12,7 @@ def allServices = services
 services.each {
     new SbtMicroserviceJobBuilder(it)
             .withScalaStyle()
-            .withSCoverage()
+            .withSCoverage('2.11')
             .withTests("test it:test")
             .build(this as DslFactory)
 }


### PR DESCRIPTION
-according to https://hmrcdigital.slack.com/archives/C518C88QN/p1579191060185200 and others this will resolve a build issue where it cannot find the Scoverage  file because it is looking in 2.12 but it exists only in 2.11